### PR TITLE
create-react-app 2.1.2 has a breaking change for webpack config file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This script is inspired by other work related such as: https://gist.github.com/j
 
 ## Ejection
 
-This tool handles ejected projects but it assumes you did not modify your `webpack.config.dev.js` file, `paths.js` and `env.js` utils. If you did I cannot guarantee that this tool will work.
+This tool handles ejected projects but it assumes you did not modify your `webpack.config.js` file, `paths.js` and `env.js` utils. If you did I cannot guarantee that this tool will work.
 
 # Why do I need this?
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -14,8 +14,8 @@ const { getReactScriptsVersion, isEjected } = require('../utils');
 const paths = isEjected ? importCwd('./config/paths') : importCwd('react-scripts/config/paths');
 const webpack = importCwd('webpack');
 const config = isEjected
-  ? importCwd('./config/webpack.config.dev')
-  : importCwd('react-scripts/config/webpack.config.dev');
+  ? importCwd('./config/webpack.config')('development')
+  : importCwd('react-scripts/config/webpack.config')('development');
 const HtmlWebpackPlugin = importCwd('html-webpack-plugin');
 const InterpolateHtmlPlugin = importCwd('react-dev-utils/InterpolateHtmlPlugin');
 const getClientEnvironment = isEjected

--- a/utils/index.js
+++ b/utils/index.js
@@ -11,7 +11,7 @@ const DEFAULT_VERSION = {
   patch: 4,
 };
 
-exports.isEjected = fs.pathExistsSync(path.join(process.cwd(), 'config/webpack.config.dev.js'));
+exports.isEjected = fs.pathExistsSync(path.join(process.cwd(), 'config/webpack.config.js'));
 
 exports.getReactScriptsVersion = function getReactScriptsVersion(cliVersion) {
   if (cliVersion) {


### PR DESCRIPTION
create-react-app 2.1.2 makes a breaking changes merging the webpack paths into  a single config. see: https://github.com/facebook/create-react-app/pull/5722

This fixes the breaking change to load the single webpack.config.js with 'development' as the environment to load.

I don't have react apps with ejected config so that path is untested. 

I have tested non-ejected create-react-app and it runs again.

to test locally: `npm i -D github:kaltepeter/cra-build-watch#update-webpack-paths`