### PR TITLE
Feature - Enable chrome extension development with HMR

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "A script for create-react-app that writes development builds to the disk",
   "main": "scripts/index.js",
   "bin": "bin/cra-build-watch.js",
-  "files": ["bin", "scripts", "utils"],
+  "files": [
+    "bin",
+    "scripts",
+    "utils"
+  ],
   "engines": {
     "node": ">=6.0.0"
   },
@@ -22,7 +26,10 @@
     }
   },
   "lint-staged": {
-    "{{bin,scripts,utils}/**/*.{js,json},*.{js,json}}": ["prettier --write", "git add"]
+    "{{bin,scripts,utils}/**/*.{js,json},*.{js,json}}": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "prettier": {
     "printWidth": 100,
@@ -61,7 +68,8 @@
     "jest": "22.4.3",
     "lint-staged": "7.0.4",
     "prettier": "1.12.1",
-    "travis-deploy-once": "^4.4.1"
+    "travis-deploy-once": "^4.4.1",
+    "webpack-merge": "^4.2.1"
   },
   "dependencies": {
     "cross-spawn": "6.0.5",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,7 @@
   "description": "A script for create-react-app that writes development builds to the disk",
   "main": "scripts/index.js",
   "bin": "bin/cra-build-watch.js",
-  "files": [
-    "bin",
-    "scripts",
-    "utils"
-  ],
+  "files": ["bin", "scripts", "utils"],
   "engines": {
     "node": ">=6.0.0"
   },
@@ -26,10 +22,7 @@
     }
   },
   "lint-staged": {
-    "{{bin,scripts,utils}/**/*.{js,json},*.{js,json}}": [
-      "prettier --write",
-      "git add"
-    ]
+    "{{bin,scripts,utils}/**/*.{js,json},*.{js,json}}": ["prettier --write", "git add"]
   },
   "prettier": {
     "printWidth": 100,
@@ -58,15 +51,15 @@
     "react-scripts": ">= 1.0.x"
   },
   "devDependencies": {
-    "@commitlint/cli": "6.1.3",
-    "@commitlint/config-conventional": "6.1.3",
+    "@commitlint/cli": "7.5.2",
+    "@commitlint/config-conventional": "7.5.0",
     "@dixeed/eslint-config": "2.0.0",
     "commitizen": "2.9.6",
     "cz-conventional-changelog": "2.1.0",
     "eslint": "4.19.1",
     "husky": "0.14.3",
     "jest": "22.4.3",
-    "lint-staged": "7.0.4",
+    "lint-staged": "^7.0.4",
     "prettier": "1.12.1",
     "travis-deploy-once": "^4.4.1"
   },
@@ -77,7 +70,6 @@
     "import-cwd": "2.1.0",
     "meow": "4.0.0",
     "ora": "2.0.0",
-    "semver": "^5.6.0",
-    "webpack-merge": "^4.2.1"
+    "semver": "^5.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "jest": "22.4.3",
     "lint-staged": "7.0.4",
     "prettier": "1.12.1",
-    "travis-deploy-once": "^4.4.1",
-    "webpack-merge": "^4.2.1"
+    "travis-deploy-once": "^4.4.1"
   },
   "dependencies": {
     "cross-spawn": "6.0.5",
@@ -78,6 +77,7 @@
     "import-cwd": "2.1.0",
     "meow": "4.0.0",
     "ora": "2.0.0",
-    "semver": "^5.6.0"
+    "semver": "^5.6.0",
+    "webpack-merge": "^4.2.1"
   }
 }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -122,6 +122,7 @@ config.plugins[htmlPluginIndex] = new HtmlWebpackPlugin({
   inject: true,
   template: paths.appHtml,
   filename: 'index.html',
+  chunks: chromeExtension ? ['main'] : undefined, // eslint-disable-line no-undefined
 });
 
 spinner.succeed();

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -76,18 +76,18 @@ const resolvedBuildPath = buildPath ? handleBuildPath(buildPath) : paths.appBuil
 // update the paths in config
 config.output.path = resolvedBuildPath;
 config.output.publicPath = publicPath || '';
-config.output.filename = `js/[name].js`;
-config.output.chunkFilename = `js/[name].chunk.js`;
+config.output.filename = chromeExtension ? 'js/[name].js' : 'js/bundle.js';
+config.output.chunkFilename = chromeExtension ? `js/[name].chunk.js` : undefined; // eslint-disable-line no-undefined
 
-// config.output.filename = "static/js/[name].js";
+if (chromeExtension) {
+  config.optimization.splitChunks = {
+    cacheGroups: {
+      default: false,
+    },
+  };
 
-config.optimization.splitChunks = {
-  cacheGroups: {
-    default: false,
-  },
-};
-
-config.optimization.runtimeChunk = false;
+  config.optimization.runtimeChunk = false;
+}
 
 // update media path destination
 if (major >= 2) {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -6,6 +6,7 @@ const importCwd = require('import-cwd');
 const fs = require('fs-extra');
 const path = require('path');
 const ora = require('ora');
+const merge = require("webpack-merge");
 
 const {
   flags: { buildPath, publicPath, reactScriptsVersion, verbose },
@@ -17,7 +18,7 @@ const { major, minor, patch } = getReactScriptsVersion(reactScriptsVersion);
 const paths = isEjected ? importCwd('./config/paths') : importCwd('react-scripts/config/paths');
 const webpack = importCwd('webpack');
 
-const config =
+const common =
   major >= 2 && minor >= 1 && patch >= 2
     ? (isEjected
         ? importCwd('./config/webpack.config')
@@ -25,6 +26,17 @@ const config =
     : isEjected
       ? importCwd('./config/webpack.config.dev')
       : importCwd('react-scripts/config/webpack.config.dev');
+
+const config = merge(common, {
+  entry: [
+    '/Users/apanizo/git/iov/ponferrada/node_modules/webpack-dev-server/client?/',
+    '/Users/apanizo/git/iov/ponferrada/node_modules/webpack/hot/dev-server',
+  ],
+  devServer: {
+    writeToDisk: true,
+    disableHostCheck: true,
+  }
+});
 
 const HtmlWebpackPlugin = importCwd('html-webpack-plugin');
 const InterpolateHtmlPlugin = importCwd('react-dev-utils/InterpolateHtmlPlugin');
@@ -42,11 +54,12 @@ const env = getClientEnvironment(process.env.PUBLIC_URL || ''); // eslint-disabl
 
 /**
  * We need to update the webpack dev config in order to remove the use of webpack devserver
- */
+ 
 config.entry = config.entry.filter(fileName => !fileName.match(/webpackHotDevClient/));
 config.plugins = config.plugins.filter(
   plugin => !(plugin instanceof webpack.HotModuleReplacementPlugin)
 );
+*/
 
 /**
  * We also need to update the path where the different files get generated.
@@ -105,7 +118,7 @@ fs
     spinner.succeed();
 
     return new Promise((resolve, reject) => {
-      const webpackCompiler = webpack(config);
+      const webpackCompiler = webpack(config);      
       webpackCompiler.apply(
         new webpack.ProgressPlugin(() => {
           if (!inProgress) {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -28,10 +28,6 @@ const common =
       : importCwd('react-scripts/config/webpack.config.dev');
 
 const config = merge(common, {
-  entry: [
-    '/Users/apanizo/git/iov/ponferrada/node_modules/webpack-dev-server/client?/',
-    '/Users/apanizo/git/iov/ponferrada/node_modules/webpack/hot/dev-server',
-  ],
   devServer: {
     writeToDisk: true,
     disableHostCheck: true,
@@ -118,7 +114,7 @@ fs
     spinner.succeed();
 
     return new Promise((resolve, reject) => {
-      const webpackCompiler = webpack(config);      
+      const webpackCompiler = webpack(config);
       webpackCompiler.apply(
         new webpack.ProgressPlugin(() => {
           if (!inProgress) {

--- a/utils/cliHandler.js
+++ b/utils/cliHandler.js
@@ -12,9 +12,11 @@ module.exports = meow(
 
       -p, --public-path Public URL.
 
-      --react-scripts-version Version of the react-scripts package used in your project i.e 2.0.3. If not given it will be implied from your package.json and if it cannot be implied the major version 2 will be the default.
+      -cs, --content-script relative URL of your content script: src/extension/contentscript.ts
 
-      -v, --verbose
+      -bs, --background-script relative URL of your backgrounc script: src/extension/bacgkroundscript.ts
+
+      --react-scripts-version Version of the react-scripts package used in your project i.e 2.0.3. If not given it will be implied from your package.json and if it cannot be implied the major version 2 will be the default.
 
     Examples
       $ cra-build-watch -b dist/ -p /assets
@@ -29,12 +31,16 @@ module.exports = meow(
         type: 'string',
         alias: 'p',
       },
+      'content-script': {
+        type: 'string',
+        alias: 'cs',
+      },
+      'background-script': {
+        type: 'string',
+        alias: 'bs',
+      },
       'react-scripts-version': {
         type: 'string',
-      },
-      verbose: {
-        type: 'boolean',
-        alias: 'v',
       },
     },
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6528,6 +6528,13 @@ webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webpack-merge@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.1.tgz#5e923cf802ea2ace4fd5af1d3247368a633489b4"
+  integrity sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==
+  dependencies:
+    lodash "^4.17.5"
+
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6528,13 +6528,6 @@ webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-merge@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.1.tgz#5e923cf802ea2ace4fd5af1d3247368a633489b4"
-  integrity sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==
-  dependencies:
-    lodash "^4.17.5"
-
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"


### PR DESCRIPTION
**Description**
This PR enables the option to pass contentscript and background script flags when developing a chrome extension, having HMR enabled.

Basic usage: 
```
// package.json
  "scripts": {
     ...
     "watch": "cra-build-watch --cs src/extension/contentscript.ts --bs src/extension/backgroundscript.ts"
  }
``` 