### PR TITLE
fix version comparison to make script work with react-script version 3.0.0

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -12,19 +12,19 @@ const {
 } = require('../utils/cliHandler');
 const { getReactScriptsVersion, isEjected } = require('../utils');
 
-const { major, minor, patch } = getReactScriptsVersion(reactScriptsVersion);
+const { major, minor, patch, concatenatedVersion } = getReactScriptsVersion(reactScriptsVersion);
 
 const paths = isEjected ? importCwd('./config/paths') : importCwd('react-scripts/config/paths');
 const webpack = importCwd('webpack');
 
 const config =
-  major >= 2 && minor >= 1 && patch >= 2
+  Number(concatenatedVersion) >= 212
     ? (isEjected
         ? importCwd('./config/webpack.config')
         : importCwd('react-scripts/config/webpack.config'))('development')
     : isEjected
-      ? importCwd('./config/webpack.config.dev')
-      : importCwd('react-scripts/config/webpack.config.dev');
+    ? importCwd('./config/webpack.config.dev')
+    : importCwd('react-scripts/config/webpack.config.dev');
 
 const HtmlWebpackPlugin = importCwd('html-webpack-plugin');
 const InterpolateHtmlPlugin = importCwd('react-dev-utils/InterpolateHtmlPlugin');
@@ -99,8 +99,7 @@ spinner.start('Clear destination folder');
 
 let inProgress = false;
 
-fs
-  .emptyDir(paths.appBuild)
+fs.emptyDir(paths.appBuild)
   .then(() => {
     spinner.succeed();
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -9,6 +9,7 @@ const DEFAULT_VERSION = {
   major: 2,
   minor: 1,
   patch: 2,
+  concatenatedVersion: '212',
 };
 
 exports.isEjected = fs.pathExistsSync(path.join(process.cwd(), 'config/paths.js'));
@@ -19,6 +20,9 @@ exports.getReactScriptsVersion = function getReactScriptsVersion(cliVersion) {
       major: Number(semver.major(cliVersion)),
       minor: Number(semver.minor(cliVersion)),
       patch: Number(semver.patch(cliVersion)),
+      concatenatedVersion: `${semver.major(cliVersion)}${semver.minor(cliVersion)}${semver.patch(
+        cliVersion
+      )}`,
     };
     return versions;
   }
@@ -33,6 +37,7 @@ exports.getReactScriptsVersion = function getReactScriptsVersion(cliVersion) {
     major: Number(semver.major(version)),
     minor: Number(semver.minor(version)),
     patch: Number(semver.patch(version)),
+    concatenatedVersion: `${semver.major(version)}${semver.minor(version)}${semver.patch(version)}`,
   };
   return versions;
 };


### PR DESCRIPTION
the problem was that major, minor and patch where not checked independently. So the next valid version for v3 would have been v 3.1.2