### PR TITLE
#64 configurable bundle output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ If those defaults do not work for you, the script accepts some arguments:
 - `-p|--public-path`: expects a relative URL where `/` is the root. If you serve your files using an external webserver this argument is to match with your web server configuration. More information can be found in [webpack configuration guide](https://webpack.js.org/configuration/output/#output-publicpath).
   - default: "".
 - `-v|--verbose`: display webpack build output.
+- `-o|--ouptput-folder`: Output folder for bundled build files under build path.  Defaults to `js` folder.
 
 # Contributions
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -9,7 +9,7 @@ const ora = require('ora');
 const assert = require('assert');
 
 const {
-  flags: { buildPath, publicPath, reactScriptsVersion, verbose, disableChunks },
+  flags: { buildPath, publicPath, reactScriptsVersion, verbose, disableChunks, outputFolder },
 } = require('../utils/cliHandler');
 const { getReactScriptsVersion, isEjected } = require('../utils');
 
@@ -54,11 +54,13 @@ config.plugins = config.plugins.filter(
  */
 const resolvedBuildPath = buildPath ? handleBuildPath(buildPath) : paths.appBuild; // resolve the build path
 
+const buildFolder = outputFolder || "js";
+
 // update the paths in config
 config.output.path = resolvedBuildPath;
 config.output.publicPath = publicPath || '';
-config.output.filename = `js/bundle.js`;
-config.output.chunkFilename = `js/[name].chunk.js`;
+config.output.filename = path.join(buildFolder, "bundle.js");
+config.output.chunkFilename = path.join(buildFolder, `[name].chunk.js`);
 
 if (disableChunks) {
   assert(major >= 2, 'Split chunks optimization is only available in react-scripts >= 2.0.0');

--- a/utils/cliHandler.js
+++ b/utils/cliHandler.js
@@ -17,6 +17,8 @@ module.exports = meow(
       --react-scripts-version Version of the react-scripts package used in your project i.e 2.0.3. If not given it will be implied from your package.json and if it cannot be implied the major version 2 will be the default.
 
       -v, --verbose
+
+      -o, --output-folder Output folder for bundled build files under build path.  Defaults to 'js' folder.
       
     Examples
       $ cra-build-watch -b dist/ -p /assets
@@ -41,6 +43,10 @@ module.exports = meow(
       'disable-chunks': {
         type: 'boolean',
       },
+      'output-folder': {
+        type: 'string',
+        alias: 'o'
+      }
     },
   }
 );


### PR DESCRIPTION
Adds an option for configuring the bundled output folder.  This is useful if you need a path structure that maps closer to what react build will output with "/static" folder.