### PR TITLE
Resolves #64 - feat(cli): adding args, bundle name, chunk naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,11 @@ If those defaults do not work for you, the script accepts some arguments:
 
 - `-b|--build-path`: expects either an absolute or relative path. If a relative path is given it will be prefixed by your project root path.
   - default: `yourProjectRoot/build`.
+- `--chunk-filename`: Set the naming you want to use for non-entry chunk files. Accepts webpack placeholders such as `[id]`, `[name]`, `[hash]`. Directories can be supplied.
+  - default: `js/bundle.js`.
 - `--disable-chunks`: disable code-splitting / chunks so that only a single bundle.js file is generated. It only works with `react-scripts` >= `2.0.0`.
+- `-o|--output-filename`: Set the name to be used for the output bundle. Accepts webpack placeholders such as `[id]`, `[name]`, `[hash]`. Directories can be supplied.
+  - default: `js/[name].chunk.js`
 - `--react-scripts-version`: expects the `react-scripts` version you are using in your project i.e `2.0.3`. If not given it will be implied from your `node_modules` and if it cannot be implied the version `2.1.2` will be the default. Consider setting it if you **ejected** and are not using the latest `react-scripts` version.
 - `-p|--public-path`: expects a relative URL where `/` is the root. If you serve your files using an external webserver this argument is to match with your web server configuration. More information can be found in [webpack configuration guide](https://webpack.js.org/configuration/output/#output-publicpath).
   - default: "".

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -9,7 +9,15 @@ const ora = require('ora');
 const assert = require('assert');
 
 const {
-  flags: { buildPath, publicPath, reactScriptsVersion, verbose, disableChunks },
+  flags: {
+    buildPath,
+    publicPath,
+    reactScriptsVersion,
+    verbose,
+    disableChunks,
+    outputFilename,
+    chunkFilename,
+  },
 } = require('../utils/cliHandler');
 const { getReactScriptsVersion, isEjected } = require('../utils');
 
@@ -57,8 +65,14 @@ const resolvedBuildPath = buildPath ? handleBuildPath(buildPath) : paths.appBuil
 // update the paths in config
 config.output.path = resolvedBuildPath;
 config.output.publicPath = publicPath || '';
-config.output.filename = `js/bundle.js`;
-config.output.chunkFilename = `js/[name].chunk.js`;
+
+// Grab output names from cli args, otherwise use some default naming.
+const fileNameToUse = outputFilename ? `${outputFilename}` : `js/bundle.js`;
+const chunkNameToUse = chunkFilename ? `${chunkFilename}` : `js/[name].chunk.js`;
+// If cli user adds .js, respect that, otherwise we add it ourself
+config.output.filename = fileNameToUse.slice(-3) != '.js' ? fileNameToUse + '.js' : fileNameToUse;
+config.output.chunkFilename =
+  chunkNameToUse.slice(-3) != '.js' ? chunkNameToUse + '.js' : chunkNameToUse;
 
 if (disableChunks) {
   assert(major >= 2, 'Split chunks optimization is only available in react-scripts >= 2.0.0');

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -67,12 +67,12 @@ config.output.path = resolvedBuildPath;
 config.output.publicPath = publicPath || '';
 
 // Grab output names from cli args, otherwise use some default naming.
-const fileNameToUse = outputFilename ? `${outputFilename}` : `js/bundle.js`;
-const chunkNameToUse = chunkFilename ? `${chunkFilename}` : `js/[name].chunk.js`;
+const fileNameToUse = outputFilename || `js/bundle.js`;
+const chunkNameToUse = chunkFilename || `js/[name].chunk.js`;
 // If cli user adds .js, respect that, otherwise we add it ourself
-config.output.filename = fileNameToUse.slice(-3) != '.js' ? fileNameToUse + '.js' : fileNameToUse;
+config.output.filename = fileNameToUse.slice(-3) !== '.js' ? `${fileNameToUse}.js` : fileNameToUse;
 config.output.chunkFilename =
-  chunkNameToUse.slice(-3) != '.js' ? chunkNameToUse + '.js' : chunkNameToUse;
+  chunkNameToUse.slice(-3) !== '.js' ? `${chunkNameToUse}.js` : chunkNameToUse;
 
 if (disableChunks) {
   assert(major >= 2, 'Split chunks optimization is only available in react-scripts >= 2.0.0');

--- a/utils/cliHandler.js
+++ b/utils/cliHandler.js
@@ -10,22 +10,38 @@ module.exports = meow(
     Options
       -b, --build-path Path to the build folder. Absolute or relative path, if relative will be prefixed with project root folder path.
 
+      --chunk-filename Set the naming you want to use for non-entry chunk files. Accepts webpack placeholders such as [id], [name], [hash]. Directories can be supplied.
+
       --disable-chunks Disable code-splitting / chunks so that only a single bundle.js file is generated. Only available in react-scripts >= 2.0.0.
+
+      -o, --output-filename Set the name to be used for the output bundle. Accepts webpack placeholders such as [id], [name], [hash]. Directories can be supplied.
 
       -p, --public-path Public URL.
 
       --react-scripts-version Version of the react-scripts package used in your project i.e 2.0.3. If not given it will be implied from your package.json and if it cannot be implied the major version 2 will be the default.
 
       -v, --verbose
-      
+
     Examples
       $ cra-build-watch -b dist/ -p /assets
+      $ cra-build-watch --chunk-filename './js/[chunkhash].[name]' -o './js/myapp'
+      $ cra-build-watch -b dist/ -p /assets --chunk-filename './js/[name]/[hash].js' -v
 `,
   {
     flags: {
       'build-path': {
         type: 'string',
         alias: 'b',
+      },
+      'chunk-filename': {
+        type: 'string',
+      },
+      'disable-chunks': {
+        type: 'boolean',
+      },
+      'output-filename': {
+        type: 'string',
+        alias: 'o',
       },
       'public-path': {
         type: 'string',
@@ -37,9 +53,6 @@ module.exports = meow(
       verbose: {
         type: 'boolean',
         alias: 'v',
-      },
-      'disable-chunks': {
-        type: 'boolean',
       },
     },
   }


### PR DESCRIPTION
Resolves #64

Allow the user to overwrite the default output bundle and chunk filenaming that this package uses. This respects webpack placeholders such as [name] and [hash].

- Add ability to provide names via cli args
- Add man text for the new cli args.
- If args are not provided, we default to using what is currently used.
- If the user omits '.js' extension from args, we apply it automatically.

To handle the user adding `.js` themselves to the name, I used the following;
` fileNameToUse.slice(-3) != '.js' ? fileNameToUse + '.js' : fileNameToUse; `
Not sure if the following would have been better/more efficient though.
`` `${fileNameToUse}`.replace(/(.js)+$/g, '.js') `` 
Would be happy to change it if needed.

I did the above as I have to allow the user to have as much control as possible over the naming/directory placement, maybe they want to have many `.js` suffixes on files.