### PR TITLE
Add an option '-e' for user to run a shell script after each build

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ If those defaults do not work for you, the script accepts some arguments:
   - default: `js/[name].chunk.js`
 - `--react-scripts-version`: expects the `react-scripts` version you are using in your project i.e `2.0.3`. If not given it will be implied from your `node_modules` and if it cannot be implied the version `2.1.2` will be the default. Consider setting it if you **ejected** and are not using the latest `react-scripts` version.
 - `-p|--public-path`: expects a relative URL where `/` is the root. If you serve your files using an external webserver this argument is to match with your web server configuration. More information can be found in [webpack configuration guide](https://webpack.js.org/configuration/output/#output-publicpath).
-  - default: "".
+  - default: `""`.
 - `-v|--verbose`: display webpack build output.
-- `-e|--postbuild`: run a script after each successful build. default: nothing to run. Example: `cra-build-watch -e "echo 'build is done'"`
+- `-e|--postbuild`: run a script after each successful build. Example: `cra-build-watch -e "echo 'build is done'"`
+  - default: `""` (nothing to run)
 
 # Contributions
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ If those defaults do not work for you, the script accepts some arguments:
 - `-p|--public-path`: expects a relative URL where `/` is the root. If you serve your files using an external webserver this argument is to match with your web server configuration. More information can be found in [webpack configuration guide](https://webpack.js.org/configuration/output/#output-publicpath).
   - default: "".
 - `-v|--verbose`: display webpack build output.
+- `-e|--postbuild`: run a script after each successful build. default: nothing to run. Example: `cra-build-watch -e "echo 'build is done'"`
 
 # Contributions
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ If those defaults do not work for you, the script accepts some arguments:
 - `-v|--verbose`: display webpack build output.
 - `-e|--postbuild`: run a script after each successful build. Example: `cra-build-watch -e "echo 'build is done'"`
   - default: `""` (nothing to run)
+- `--run-once`: only build once and exit, to mimic a build process
+  - default: `false`  
 
 # Contributions
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -123,6 +123,7 @@ spinner.succeed();
 spinner.start('Clear destination folder');
 
 let inProgress = false;
+let first = true;
 
 fs.emptyDir(paths.appBuild)
   .then(() => {
@@ -156,6 +157,23 @@ fs.emptyDir(paths.appBuild)
           console.log();
         }
 
+        if (postbuild && !first) {
+          spinner.start('Running postbuild script');
+          exec(postbuild, (error, stdout, stderr) => {
+            if (error) {
+              spinner.failed(error.message);
+              return;
+            }
+            if (stderr) {
+              spinner.warn(`stderr: ${stderr.trim()}`);
+              return;
+            }
+            spinner.succeed();
+          });
+        }
+
+        first = false;
+
         return resolve();
       });
     });
@@ -177,7 +195,8 @@ fs.emptyDir(paths.appBuild)
         spinner.succeed();
       });
     }
-  });
+  })
+;
 
 function copyPublicFolder() {
   return fs.copy(paths.appPublic, resolvedBuildPath, {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -7,6 +7,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const ora = require('ora');
 const assert = require('assert');
+const { exec } = require("child_process");
 
 const {
   flags: {
@@ -17,6 +18,7 @@ const {
     disableChunks,
     outputFilename,
     chunkFilename,
+    postbuild
   },
 } = require('../utils/cliHandler');
 const { getReactScriptsVersion, isEjected } = require('../utils');
@@ -152,6 +154,20 @@ fs.emptyDir(paths.appBuild)
             })
           );
           console.log();
+        }
+
+        if (postbuild) {
+          exec(postbuild, (error, stdout, stderr) => {
+            if (error) {
+              console.log(`error: ${error.message}`);
+              return;
+            }
+            if (stderr) {
+              console.log(`stderr: ${stderr}`);
+              return;
+            }
+            console.log(`stdout: ${stdout}`);
+          });
         }
 
         return resolve();

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -7,7 +7,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const ora = require('ora');
 const assert = require('assert');
-const { exec } = require("child_process");
+const { exec } = require('child_process');
 
 const {
   flags: {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -156,25 +156,28 @@ fs.emptyDir(paths.appBuild)
           console.log();
         }
 
-        if (postbuild) {
-          exec(postbuild, (error, stdout, stderr) => {
-            if (error) {
-              console.log(`error: ${error.message}`);
-              return;
-            }
-            if (stderr) {
-              console.log(`stderr: ${stderr}`);
-              return;
-            }
-            console.log(`stdout: ${stdout}`);
-          });
-        }
-
         return resolve();
       });
     });
   })
-  .then(() => copyPublicFolder());
+  .then(() => copyPublicFolder())
+  .then((resolve, reject) => {
+    if (postbuild) {
+      spinner.start('Running postbuild script');
+      exec(postbuild, (error, stdout, stderr) => {
+        if (error) {
+          spinner.failed(error.message);
+          reject(error);
+          return;
+        }
+        if (stderr) {
+          spinner.warn(`stderr: ${stderr.trim()}`);
+          return;
+        }
+        spinner.succeed();
+      });
+    }
+  });
 
 function copyPublicFolder() {
   return fs.copy(paths.appPublic, resolvedBuildPath, {

--- a/utils/cliHandler.js
+++ b/utils/cliHandler.js
@@ -57,6 +57,9 @@ module.exports = meow(
       postbuild: {
         type: 'string',
         alias: 'e'
+      },
+      'run-once': {
+        type: 'boolean',
       }
     },
   }

--- a/utils/cliHandler.js
+++ b/utils/cliHandler.js
@@ -54,6 +54,10 @@ module.exports = meow(
         type: 'boolean',
         alias: 'v',
       },
+      postbuild: {
+        type: 'string',
+        alias: 'e'
+      }
     },
   }
 );


### PR DESCRIPTION
Usage:
```
cra-build-watch -e "echo 'build is done'"
```
Sometimes we may need to run routine after each build. I add this option to upload my build output to my remote server, and believe this would be useful for other uses.