### PR TITLE
Update node requirement version & update semantic-release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "utils"
   ],
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,23 @@
     "trailingComma": "es5",
     "singleQuote": true
   },
+  "release": {
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "master",
+      "next",
+      "deploy",
+      "next-major",
+      {
+        "name": "beta",
+        "prerelease": true
+      },
+      {
+        "name": "alpha",
+        "prerelease": true
+      }
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Nargonath/cra-build-watch.git"


### PR DESCRIPTION
The node engines changes is just a fix because a breaking change was already done in the past for the drop of node 6 & 8.