### PR TITLE
Added argument to set weppack.watch option polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ If those defaults do not work for you, the script accepts some arguments:
 - `-p|--public-path`: expects a relative URL where `/` is the root. If you serve your files using an external webserver this argument is to match with your web server configuration. More information can be found in [webpack configuration guide](https://webpack.js.org/configuration/output/#output-publicpath).
   - default: "".
 - `-v|--verbose`: display webpack build output.
+- `--watchOptionPoll`: expects a number of milliseconds to enable polling, which can help if watching does not work. More information can be found in  [webpack configuration guide](https://webpack.js.org/configuration/watch/#watchoptionspoll).
 
 # Contributions
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -21,6 +21,7 @@ const {
     chunkFilename,
     afterInitialBuildHook,
     afterRebuildHook,
+    watchOptionsPoll,
   },
 } = require('../utils/cliHandler');
 const { getReactScriptsVersion, isEjected } = require('../utils');
@@ -145,8 +146,11 @@ fs.emptyDir(paths.appBuild)
           inProgress = true;
         }
       }).apply(webpackCompiler);
-
-      webpackCompiler.watch({}, (err, stats) => {
+      
+      let watchOptions = {
+        poll: watchOptionsPoll || false
+      };
+      webpackCompiler.watch(watchOptions, (err, stats) => {
         if (err) {
           return reject(err);
         }


### PR DESCRIPTION
This helps with issues with NFS and machines in VirtualBox, WSL, Containers, or Docker

See https://webpack.js.org/configuration/watch/#watchoptionspoll